### PR TITLE
Add Smart Thermostat ROI calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is the official landing page for **O'Neil Fuller**, a Certified Master HVAC
   - HVACR for Kids
 - Contact form for inquiries and connection
 - Responsive design for desktop and mobile
+- Smart Thermostat ROI calculator to estimate potential savings
 
 ## Usage
 
@@ -37,6 +38,7 @@ You can publish this landing page easily using services like:
 ## Files
 
 - `index.html` — The main landing page HTML file.
+- `roi-calculator.js` — Script powering the ROI calculator.
 
 ## License
 

--- a/index.html
+++ b/index.html
@@ -67,6 +67,20 @@
     <a href="#contact" class="button">Get in Touch</a>
   </section>
 
+  <section class="roi" id="roi">
+    <h2>Smart Thermostat ROI Calculator</h2>
+    <form id="roi-form">
+      <input type="number" id="monthly" placeholder="Monthly Energy Bill ($)" min="0" step="0.01" required />
+      <input type="number" id="savings" placeholder="Expected Savings (%)" min="0" max="100" step="1" required />
+      <input type="number" id="thermostat-cost" placeholder="Smart Thermostat Cost ($)" min="0" step="0.01" required />
+      <input type="submit" value="Calculate ROI" />
+    </form>
+    <div id="roi-results" style="display: none;">
+      <p id="annual-savings"></p>
+      <p id="payback-period"></p>
+      <p id="roi-value"></p>
+    </div>
+  </section>
   <section class="contact" id="contact">
     <h2>Contact O'Neil</h2>
     <form action="#" method="post">
@@ -80,5 +94,6 @@
   <footer>
     <p>&copy; 2025 O'Neil Fuller. All rights reserved.</p>
   </footer>
+  <script src="roi-calculator.js"></script>
 </body>
 </html>

--- a/roi-calculator.js
+++ b/roi-calculator.js
@@ -1,0 +1,29 @@
+// Smart Thermostat ROI Calculator
+window.addEventListener('DOMContentLoaded', function () {
+  var form = document.getElementById('roi-form');
+  if (!form) return;
+  var results = document.getElementById('roi-results');
+  var annualEl = document.getElementById('annual-savings');
+  var paybackEl = document.getElementById('payback-period');
+  var roiEl = document.getElementById('roi-value');
+
+  form.addEventListener('submit', function (e) {
+    e.preventDefault();
+    var monthly = parseFloat(document.getElementById('monthly').value) || 0;
+    var savingsPercent = parseFloat(document.getElementById('savings').value) || 0;
+    var cost = parseFloat(document.getElementById('thermostat-cost').value) || 0;
+    if (monthly <= 0 || savingsPercent <= 0 || cost <= 0) {
+      results.style.display = 'none';
+      return;
+    }
+    var monthlySavings = monthly * (savingsPercent / 100);
+    var annualSavings = monthlySavings * 12;
+    var paybackMonths = cost / monthlySavings;
+    var roi = ((annualSavings - cost) / cost) * 100;
+
+    annualEl.textContent = 'Estimated annual savings: $' + annualSavings.toFixed(2);
+    paybackEl.textContent = 'Payback period: ' + paybackMonths.toFixed(1) + ' months';
+    roiEl.textContent = 'Estimated ROI: ' + roi.toFixed(1) + '%';
+    results.style.display = 'block';
+  });
+});


### PR DESCRIPTION
## Summary
- add Smart Thermostat ROI calculator section to the landing page
- include `roi-calculator.js` script for calculations
- document the new feature in README

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684728f40ee48329a4ec05644f2fd1fd