### PR TITLE
Add navigation bar linking to books and contact

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <style>
     body { font-family: Arial, sans-serif; margin: 0; padding: 0; line-height: 1.6; color: #333; background-color: #f8f9fa; }
     header { background-color: #005f73; color: #fff; padding: 2rem; text-align: center; }
+    nav { background-color: #005f73; text-align: center; padding: 0.5rem; }
     nav a { color: #fff; margin: 0 1rem; text-decoration: none; font-weight: bold; }
     section { padding: 2rem; max-width: 1000px; margin: auto; }
     h1, h2 { color: #0a9396; }
@@ -33,13 +34,18 @@
     <p>HVACR Educator | Author | Industry Innovator</p>
   </header>
 
+  <nav>
+    <a href="#books">Books</a>
+    <a href="#contact">Contact</a>
+  </nav>
+
   <section class="bio">
     <h2>Meet O'Neil</h2>
     <p>O’Neil Fuller is a Certified Master HVACR Educator with over 20 years of experience in leading, designing, and advancing HVACR programs. He has taught at top institutions like Kroger, Tulsa Welding/HVAC School, and Georgia Piedmont Technical College. His expertise spans curriculum development, energy efficiency, refrigeration, and emerging technologies.</p>
     <p>He is certified by NATE, ICE, EPA, and HVAC Excellence, and he’s on a mission to modernize the HVACR trade — from the classroom to the job site, and even the bookshelf.</p>
   </section>
 
-  <section class="books">
+  <section class="books" id="books">
     <h2>Books by O'Neil</h2>
 
     <div class="book">


### PR DESCRIPTION
## Summary
- add nav section with links to Books and Contact
- style nav to match the header
- add `id="books"` to Books section so links work

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685ace5b385c8329ac4a0fd893fb60b8